### PR TITLE
Added dot symbol to popover docs

### DIFF
--- a/apps/ngx-popovers/src/app/pages/page-popover/page-popover.component.html
+++ b/apps/ngx-popovers/src/app/pages/page-popover/page-popover.component.html
@@ -4,7 +4,7 @@
   <section class="py-4">
     <h2 class="text-4xl mb-4 font-bold">About</h2>
     <p>
-      Popover component displays content next to the trigger element on mouse click
+      Popover component displays content next to the trigger element on mouse click.
       It can be rendered into any component you want with <code class="code">bindTo</code> input
     </p>
     <br>


### PR DESCRIPTION
Hello, author!

It's the smallest fix, I've ever done.  Just look, how it's seen before my changes:

![Screenshot_5](https://github.com/al-march/ngx-popovers/assets/56767227/84b35753-1240-4e53-9eb5-c40d927fbe96)

For example, page with tooltip looks correctly:

![Screenshot_4](https://github.com/al-march/ngx-popovers/assets/56767227/7f6a74e8-bfa0-4ba3-935d-0b5fbad1c549)

